### PR TITLE
修复了之前因缩进错误导致逻辑出错的bug

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -75,9 +75,9 @@ if __name__ == '__main__':
     else:
         if sys.platform == 'linux':
             if "XDG_CURRENT_DESKTOP" in os.environ:
-                itchat.auto_login(hotReload=True, enableCmdQR=2)
-            else:
                 itchat.auto_login(hotReload=True)
+            else:
+                itchat.auto_login(hotReload=True, enableCmdQR=2)
         else:
             itchat.auto_login(hotReload=True)
                 

--- a/Main.py
+++ b/Main.py
@@ -1,6 +1,7 @@
 # -*-encoding:utf-8-*-
 
 import sys
+import os
 import itchat
 from itchat.content import *
 import traceback
@@ -67,9 +68,15 @@ if __name__ == '__main__':
     #itchat.auto_login(hotReload=True)
     # 使用命令行登录，选此条语句，参数选2或者1，根据不同机器的字符宽度决定，大家挨个尝试
     #itchat.auto_login(hotReload=True, enableCmdQR=2)
+         
     if len(sys.argv) > 1:
         if sys.argv[1] == '-t':
             itchat.auto_login(hotReload=True, enableCmdQR=2)
+    else:
+        if sys.platform == 'linux':
+            if "XDG_CURRENT_DESKTOP" in os.environ:
+                itchat.auto_login(hotReload=True, enableCmdQR=2)
         else:
             itchat.auto_login(hotReload=True)
+                
     itchat.run()

--- a/Main.py
+++ b/Main.py
@@ -76,6 +76,8 @@ if __name__ == '__main__':
         if sys.platform == 'linux':
             if "XDG_CURRENT_DESKTOP" in os.environ:
                 itchat.auto_login(hotReload=True, enableCmdQR=2)
+            else:
+                itchat.auto_login(hotReload=True)
         else:
             itchat.auto_login(hotReload=True)
                 


### PR DESCRIPTION
很抱歉这么晚打扰。之前发pull request时的代码因为缩进错误导致逻辑出错，已经修复。
顺便作为补偿，加了个Linux下的桌面or命令行自识别（未大量测试，本人的Debian8开发机暂无问题）
win下不加-t默认是弹出图片查看器